### PR TITLE
Added CSS-changes for the smaller screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -74,7 +74,7 @@ body {
 .navbar {
   display: flex;
   align-items: center;
-  padding: 20px;
+  padding: 20px 5px;
 }
 
 nav {
@@ -155,6 +155,7 @@ p {
   border: none;
   outline: none;
   cursor: pointer;
+  z-index: 1;
 }
 
 #btnScrollToTop:active{
@@ -165,7 +166,7 @@ p {
 
 .col-2 {
   flex-basis: 50%;
-  min-width: 300px;
+  min-width: 280px;
 }
 
 .col-2 img {
@@ -426,7 +427,7 @@ ul {
 
 .menu-icon {
   width: 28px;
-  margin-left: 20px;
+  margin-left: 10px;
   display: none;
 }
 
@@ -783,6 +784,10 @@ form a {
     flex-basis: 100%;
   }
 
+  .col-2 p {
+    margin: auto;
+  }
+
   .single-product .row {
     text-align: left;
   }
@@ -955,7 +960,7 @@ form a {
 .toggle{
   width: 40px;
   height: 22px;
-  margin-left: 30px;
+  margin-left: 25px;
   background-color: whitesmoke;
   border-radius: 30px;    
   display: flex;


### PR DESCRIPTION
Hello,

I've noticed that on the smaller screens (Galaxy Fold in particular) the content doesn't fit, and, due to this, the page can be scrolled horizontally. I've made **a few CSS-changes**, so it can fit.

In particular (6 changes):

- for the **navbar** class I've changed _padding from 20px to 20px 5px_;
- for the **btnScrollToTop** id I've added _z-index: 1_ (so the button for scrolling to the top can be displayed above all the content);
- for the **col-2** class I've changed _min-width from 300px to 280px_;
- for the **menu-icon** class I've changed _margin-left from 20px to 10px_;
- I've also added _margin: auto_ for the paragraphs on the screens with max-width: 600px; I've accessed them with **.col-2 p**;
- lastly I've changed _margin-left_ for the **toggle** class _from 30px to 25px_;

I've checked the other screens after that, and so far it fits there as well.

I hope this could be helpful.